### PR TITLE
Update devtool

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,7 +7,7 @@ module.exports =  (env, argv) => {
 		output: {
 			filename: 'bundle.js'
 		},
-		devtool: isDevelopment() ? 'cheap-module-eval-source-map' : 'source-map',
+		devtool: isDevelopment() ? 'cheap-module-source-map' : 'source-map',
 		module: {
 			rules: [
 				{


### PR DESCRIPTION
Invalid configuration object. Webpack has been initialized using a configuration object that does not 
match the API schema.